### PR TITLE
Update highcharts-ng loading property

### DIFF
--- a/highcharts-ng/highcharts-ng.d.ts
+++ b/highcharts-ng/highcharts-ng.d.ts
@@ -17,7 +17,7 @@ interface HighChartsNGConfig {
     };
     //Boolean to control showng loading status on chart (optional)
     //Could be a string if you want to show specific loading text.
-    loading?: boolean;
+    loading?: boolean | string;
     //Configuration for the xAxis (optional). Currently only one x axis can be dynamically controlled.
     //properties currentMin and currentMax provied 2-way binding to the chart's maximimum and minimum
     xAxis?: {


### PR DESCRIPTION
Per Issue #8691, the `loading` property can be a `boolean` or a `string` value.

In the highcharts-ng source code, located at https://github.com/pablojim/highcharts-ng/blob/master/src/highcharts-ng.js, the `loading` property is used in multiple places. However, line 429 references an area where it is supplied as a parameter to highchart's `showLoading` method.

In the highcharts source code, the `showLoading` method is defined in this file; an excerpt of which is included below: https://github.com/highcharts/highcharts/blob/b02a4d7de9bc6629bc72aea5fe0f7a2ac4792fe9/js/parts/Dynamics.js

```
showLoading: function (str) {
    /* ... */

    // update text
    chart.loadingSpan.innerHTML = str || options.lang.loading;

    /* ... */
}
```

Based on these findings plus Issue #8691, I've added the `string` type as a possibility for this property.
